### PR TITLE
Ajout de l'aide pour les habitants de la CC des Vallons du Lyonnais 

### DIFF
--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -326,6 +326,16 @@ aides . les sables d'olonne:
       - sinon: 100€
   lien: http://www.lsoagglo.fr/vivreauxolonnes/vie-pratique/transports/plan-velo-2025/
 
+aides . vallons du lyonnais:
+  remplace: commune
+  titre: Communauté de Communes des Vallons du Lyonnais
+  applicable si:
+    toutes ces conditions:
+      - localisation . epci = 'CC des Vallons du Lyonnais (CCVL)'
+      - vélo . électrique
+  valeur: 200€
+  lien: http://www.ccvl.fr/page.php?page=DT1620223333
+
 #####################################################################
 
 vélo: oui


### PR DESCRIPTION
Les habitants de la CC des Vallons du Lyonnais disposent d'une aide de 200€ sur l'achat d'un vélo électrique neuf dans un magasin du département (sans condition de ressource)

Informations : http://www.ccvl.fr/page.php?page=DT1620223333