### PR TITLE
Ajoute les aides à l'achat pour la commune de Mondeville (Calvados)

### DIFF
--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -306,6 +306,80 @@ aides . caen:
   plafond: vélo . prix
   lien: https://caen.fr/velo-pied
 
+aides . mondeville:
+  remplace: commune
+  titre: Ville de Mondeville
+  condition de ressources: oui
+  applicable si:
+    toutes ces conditions:
+      - localisation . code postal = '14120'
+    - une de ces conditions:
+        - vélo . cargo
+        - vélo . électrique
+        - vélo
+  variations:
+    - si: vélo . électrique
+      alors:
+        grille:
+          assiette: revenu fiscal de référence
+          tranches:
+            - plafond: 620 €/mois
+              montant:
+                valeur: 300€
+                plafond:
+                  variations:
+                    - si: revenu fiscal de référence <= 13489 €/an
+                      alors: 500€
+            - plafond: 920 €/mois
+              montant:
+                valeur: 200€
+                plafond:
+                  variations:
+                    - si: revenu fiscal de référence <= 13489 €/an
+                      alors: 400€
+            - plafond: 1200 €/mois
+              montant:
+                valeur: 100€
+                plafond:
+                  variations:
+                    - si: revenu fiscal de référence <= 13489 €/an
+                      alors: 200€
+    - si: vélo . cargo
+      alors:
+        grille:
+          assiette: revenu fiscal de référence
+          tranches:
+            - plafond: 620 €/mois
+              montant:
+                valeur: 400€
+                plafond:
+                  variations:
+                    - si: revenu fiscal de référence <= 13489 €/an
+                      alors: 600€
+            - plafond: 920 €/mois
+              montant:
+                valeur: 300€
+                plafond:
+                  variations:
+                    - si: revenu fiscal de référence <= 13489 €/an
+                      alors: 500€
+            - plafond: 1200 €/mois
+              montant:
+                valeur: 200€
+                plafond:
+                  variations:
+                    - si: revenu fiscal de référence <= 13489 €/an
+                      alors: 300€
+    - si: vélo
+      alors:
+        grille:
+          assiette: revenu fiscal de référence
+          tranches:
+            - plafond: 620 €/mois
+              montant:
+                valeur: 50€
+  lien: http://www.mondeville.fr/vivre_a_mondeville/prime_a_l_achat_d_un_velo.html
+
 aides . les sables d'olonne:
   remplace: commune
   titre: Les Sables d'Olonne

--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -318,14 +318,11 @@ aides . mondeville:
           assiette: revenu fiscal de référence
           tranches:
             - plafond: 620 €/mois
-              montant:
-                valeur: 300€
+              montant: 300€
             - plafond: 920 €/mois
-              montant:
-                valeur: 200€
+              montant: 200€
             - plafond: 1200 €/mois
-              montant:
-                valeur: 100€
+              montant: 100€
     - si: vélo . cargo
       alors:
         grille:

--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -310,13 +310,7 @@ aides . mondeville:
   remplace: commune
   titre: Ville de Mondeville
   condition de ressources: oui
-  applicable si:
-    toutes ces conditions:
-      - localisation . code postal = '14120'
-      - une de ces conditions:
-        - vélo . cargo
-        - vélo . électrique
-        - vélo
+  applicable si: localisation . code postal = '14120'
   variations:
     - si: vélo . électrique
       alors:

--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -326,24 +326,12 @@ aides . mondeville:
             - plafond: 620 €/mois
               montant:
                 valeur: 300€
-                plafond:
-                  variations:
-                    - si: revenu fiscal de référence <= 13489 €/an
-                      alors: 500€
             - plafond: 920 €/mois
               montant:
                 valeur: 200€
-                plafond:
-                  variations:
-                    - si: revenu fiscal de référence <= 13489 €/an
-                      alors: 400€
             - plafond: 1200 €/mois
               montant:
                 valeur: 100€
-                plafond:
-                  variations:
-                    - si: revenu fiscal de référence <= 13489 €/an
-                      alors: 200€
     - si: vélo . cargo
       alors:
         grille:
@@ -352,24 +340,12 @@ aides . mondeville:
             - plafond: 620 €/mois
               montant:
                 valeur: 400€
-                plafond:
-                  variations:
-                    - si: revenu fiscal de référence <= 13489 €/an
-                      alors: 600€
             - plafond: 920 €/mois
               montant:
                 valeur: 300€
-                plafond:
-                  variations:
-                    - si: revenu fiscal de référence <= 13489 €/an
-                      alors: 500€
             - plafond: 1200 €/mois
               montant:
                 valeur: 200€
-                plafond:
-                  variations:
-                    - si: revenu fiscal de référence <= 13489 €/an
-                      alors: 300€
     - si: vélo
       alors:
         grille:

--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -313,7 +313,7 @@ aides . mondeville:
   applicable si:
     toutes ces conditions:
       - localisation . code postal = '14120'
-    - une de ces conditions:
+      - une de ces conditions:
         - vélo . cargo
         - vélo . électrique
         - vélo
@@ -338,22 +338,18 @@ aides . mondeville:
           assiette: revenu fiscal de référence
           tranches:
             - plafond: 620 €/mois
-              montant:
-                valeur: 400€
+              montant: 400€
             - plafond: 920 €/mois
-              montant:
-                valeur: 300€
+              montant: 300€
             - plafond: 1200 €/mois
-              montant:
-                valeur: 200€
-    - si: vélo
+              montant: 200€
+    - si: vélo . mécanique
       alors:
         grille:
           assiette: revenu fiscal de référence
           tranches:
             - plafond: 620 €/mois
-              montant:
-                valeur: 50€
+              montant: 50€
   lien: http://www.mondeville.fr/vivre_a_mondeville/prime_a_l_achat_d_un_velo.html
 
 aides . les sables d'olonne:


### PR DESCRIPTION
Les données sont issues de la page http://www.mondeville.fr/vivre_a_mondeville/prime_a_l_achat_d_un_velo.html