### PR TITLE
Support des villes avec plusieurs codes postaux

### DIFF
--- a/src/lib/data-communes.js
+++ b/src/lib/data-communes.js
@@ -44,6 +44,9 @@ const data = [
 		.map((c) => ({
 			...c,
 			...(communesInEpci[c.code] ? { epci: communesInEpci[c.code] } : {}),
+			codesPostaux: villesAvecArrondissements[c.nom]
+				? [villesAvecArrondissements[c.nom], ...c.codesPostaux]
+				: c.codesPostaux,
 			codePostal: villesAvecArrondissements[c.nom] ?? c.codesPostaux[0]
 		})),
 	...extraData


### PR DESCRIPTION
Fix #75, fix #56

Quand le fichier de données comportait plusieurs codes postaux pour une même ville, on ne prenait en compte que le premier, désormais tous les codes postaux peuvent être cherchés.

En revanche quand on cherche via le nom d'une ville j'ai veillé à ce qu'il n'y a pas de déduplications de lignes comme sur d'autres sites, seul le code postal principal est affiché :

![image](https://user-images.githubusercontent.com/1730702/145805867-0c5c689d-4503-4edd-afe2-39b5d977ca80.png)
![image](https://user-images.githubusercontent.com/1730702/145805947-1d27e793-bd77-4885-b264-016772ec2e99.png)

Le fichier de données contient quelques erreurs où une ville possède à la fois son propre code postal mais aussi celui d'une commune limitrophe. J'ai remonté le soucis via https://github.com/etalab/decoupage-administratif/issues/25