### PR TITLE
Allège le paquet NPM

### DIFF
--- a/package-aides-velo/index.ts
+++ b/package-aides-velo/index.ts
@@ -1,6 +1,6 @@
 import Publicodes from 'publicodes';
 import aides from '../src/aides.yaml';
-import { aidesRuleNames, associateCollectivityMetadata } from '$lib/aides-analysis';
+import aidesAndCollectivities from '../src/lib/data/aides-collectivities.json';
 
 type Aide = {
 	title: string;
@@ -32,10 +32,10 @@ const engine = new Publicodes(aides as any);
 export default function aidesVelo(situation: InputParameters): Array<Aide> {
 	engine.setSituation(formatInput(situation));
 
-	return aidesRuleNames
+	return Object.keys(aidesAndCollectivities)
 		.map((ruleName) => {
 			const rule = engine.getRule(ruleName);
-			const collectivity = associateCollectivityMetadata(rule).collectivity;
+			const collectivity = aidesAndCollectivities[ruleName].collectivity;
 			const { nodeValue } = engine.evaluate({ valeur: ruleName, unité: '€' });
 
 			return {

--- a/package-aides-velo/package.json
+++ b/package-aides-velo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aides-velo",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Les aides vélos proposées en France",
 	"author": "Maxime Quandalle <maxime@mesaidesvelo.fr>",
 	"license": "MIT",

--- a/src/lib/readWriteJson.js
+++ b/src/lib/readWriteJson.js
@@ -11,9 +11,13 @@
 import fs from 'fs';
 import { join, dirname } from 'path';
 
-export function loadJsonFile(path) {
+export function loadTextFile(path) {
 	const absolutePath = new URL(join('../../', path), import.meta.url).pathname;
-	return JSON.parse(fs.readFileSync(absolutePath, 'utf8'));
+	return fs.readFileSync(absolutePath, 'utf8');
+}
+
+export function loadJsonFile(path) {
+	return JSON.parse(loadTextFile(path));
 }
 
 export function writeJsonFile(path, data) {

--- a/src/routes/liste-aides.svelte
+++ b/src/routes/liste-aides.svelte
@@ -1,8 +1,8 @@
 <script>
-	import { aidesRuleNames, associateCollectivityMetadata } from '$lib/aides-analysis';
 	import AideSummary from '$lib/components/AideSummary.svelte';
 	import { engine } from '$lib/engine';
 	import departements from '@etalab/decoupage-administratif/data/departements.json';
+	import aidesCollectivities from '$lib/data/aides-collectivities.json';
 
 	const groupBy = (list, f) =>
 		list.reduce((acc, elm) => {
@@ -13,9 +13,10 @@
 			};
 		}, {});
 
-	const associatedCollectivities = aidesRuleNames.map((ruleName) =>
-		associateCollectivityMetadata(engine.getRule(ruleName))
-	);
+	const associatedCollectivities = Object.keys(aidesCollectivities).map((ruleName) => ({
+		...engine.getRule(ruleName),
+		...aidesCollectivities[ruleName]
+	}));
 
 	const aidesEtat = associatedCollectivities.filter(
 		({ collectivity }) => collectivity.kind === 'pays' && collectivity.value === 'France'

--- a/src/scripts/postinstall.js
+++ b/src/scripts/postinstall.js
@@ -1,1 +1,2 @@
 import './transform-communes-data.js';
+import './associate-collectivities.js';


### PR DESCRIPTION
Suite à l'ajout récent d'une logique permettant d'associer une aide à une collectivité, la liste complète des villes, départements et régions était incluse dans le paquet distribué sur NPM. cf. https://github.com/mquandalle/mesaidesvelo/pull/94#issuecomment-1002170237

Ajout d'un script permettant de réaliser cette association lors du build et de ne publier sur NPM que la liste des associations sous la forme d'un JSON léger.

cc @guillett 
