### PR TITLE
Rendre accessible dans le package aides-velo src/lib/data/aides-collectivities.json

### DIFF
--- a/package-aides-velo/index.ts
+++ b/package-aides-velo/index.ts
@@ -49,6 +49,8 @@ export default function aidesVelo(situation: InputParameters): Array<Aide> {
 		.filter(({ amount, url }) => amount && url);
 }
 
+aidesVelo.aidesAndCollectivities = aidesAndCollectivities;
+
 const formatInput = (input: InputParameters) =>
 	Object.fromEntries(
 		Object.entries(input).map(([key, val]) => [


### PR DESCRIPTION
C'est une implémentation plutôt sale mais ça donne une idée.

Ça permettrait d'éviter la construction d'une correspondance manuelle côté client https://github.com/betagouv/aides-jeunes/pull/2022/files#diff-3e73d93ceef10986c3e4dc162e2ee91fe79a1108ed3062846e6e163dc6f38182