### PR TITLE
API du paquet

### DIFF
--- a/package-aides-velo/README.md
+++ b/package-aides-velo/README.md
@@ -5,3 +5,30 @@ Ce paquet est un emballage léger autour du moteur [publicodes](https://publi.co
 Idéalement on ne devrait pas avoir besoin de ce paquet, en effet on pourrait utiliser directement l'API publicodes pour récupérer toutes les informations utiles depuis la base de règles. Cela nécessite sans doute encore quelques améliorations côté publicodes pour que être réellement facile à utiliser. Et donc en attendant ce paquet joue le rôle de “colle” pour faciliter l'interfaçage, et garantir la retro-compatibilité en cas d'évolutions du moteur sous-jacent.
 
 Les aides sont explorables sur https://mesaidesvelo.fr
+
+## API
+
+Pour obtenir la liste de toutes les aides vélo :
+
+```js
+import aidesVelo from 'aides-velo';
+
+console.log(aidesVelo());
+```
+
+Il est possible de reseindre cette liste à un pays en particulier :
+
+```js
+aidesVelo({ 'localisation . pays': 'france' });
+```
+
+Par défaut le montant de l'aide n'est pas donné. En effet il dépend du type de vélo, ce que l'on peut préciser avec `vélo . type` :
+
+```js
+aidesVelo({
+	'localisation . pays': 'france',
+	'vélo . type': 'électrique'
+});
+```
+
+Le montant de l'aide peut être affiné avec d'autres variables en entrée. La liste est disponible via le typage Typescript. D'autres exemples sont disponibles dans le fichier de tests.

--- a/package-aides-velo/package.json
+++ b/package-aides-velo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aides-velo",
-	"version": "1.1.2",
+	"version": "2.0.0",
 	"description": "Les aides vélos proposées en France",
 	"author": "Maxime Quandalle <maxime@mesaidesvelo.fr>",
 	"license": "MIT",

--- a/package-aides-velo/test.js
+++ b/package-aides-velo/test.js
@@ -1,10 +1,26 @@
 import test from 'ava';
 import aidesVelo from 'aides-velo';
 
+test('toutes les aides ont un titre et un lien', (t) => {
+	aidesVelo().forEach((aide) => {
+		t.truthy(aide.title, `${aide.id} a un titre`);
+		t.truthy(aide.url, `${aide.id} a un lien`);
+	});
+});
+
+test('liste des aides en France', (t) => {
+	const list = aidesVelo({ 'localisation . pays': 'france' });
+	t.assert(list.length > 50, 'au moins 50 aides en France');
+	t.false(
+		list.some(({ id: aideId }) => aideId.includes('monaco') || aideId.includes('luxembourg')),
+		"pas d'aides de Monaco ou du Luxembourg"
+	);
+});
+
 test('aides électrique colmar', (t) => {
 	const colmarElectrique = aidesVelo({
 		'localisation . code insee': '68066',
-		'localisation . epci': 'CA Colmar Agglomération',
+		'localisation . epci': '246800726',
 		'localisation . département': '68',
 		'localisation . région': '44',
 		'vélo . type': 'électrique'
@@ -19,7 +35,7 @@ test('aides électrique colmar', (t) => {
 test('motorisation vélo strasboug', (t) => {
 	const strasbourgMotorisation = aidesVelo({
 		'localisation . code insee': '67482',
-		'localisation . epci': 'Eurométropole de Strasbourg',
+		'localisation . epci': '246700488',
 		'localisation . département': '67',
 		'localisation . région': '44',
 		'vélo . type': 'motorisation'
@@ -28,7 +44,46 @@ test('motorisation vélo strasboug', (t) => {
 	t.is(strasbourgMotorisation[0].amount, 150, '150 euros');
 	t.deepEqual(
 		strasbourgMotorisation[0].collectivity,
-		{ kind: 'epci', value: 'Eurométropole de Strasbourg' },
+		{ kind: 'epci', value: 'Eurométropole de Strasbourg', code: '246700488' },
 		"Associée à l'EPCI de Strasbourg"
+	);
+});
+
+test('prise en compte du revenu fiscal de référence', (t) => {
+	const situationCharenton = {
+		'localisation . code insee': '94018',
+		'vélo . type': 'électrique'
+	};
+	const aidesCharenton = aidesVelo(situationCharenton);
+	t.is(
+		aidesCharenton.reduce((sum, { amount }) => sum + amount, 0),
+		400,
+		"jusqu'à 400 euros d'aides"
+	);
+	const aidesCharentonRevenuElevé = aidesVelo({
+		...situationCharenton,
+		'revenu fiscal de référence': '5000 €/mois'
+	});
+	t.is(
+		aidesCharentonRevenuElevé.reduce((sum, { amount }) => sum + amount, 0),
+		0,
+		"pas d'aides pour un RFR à 5000 €/mois/part"
+	);
+});
+
+test('interpolation des variables $vélo et $plafond', (t) => {
+	aidesVelo({
+		'localisation . pays': 'france',
+		'localisation . code insee': '75056',
+		'localisation . epci': '200054781',
+		'localisation . département': '75',
+		'localisation . région': '11',
+		'vélo . type': 'électrique'
+	}).forEach(({ id, description }) =>
+		t.notRegex(
+			description,
+			/\$(vélo|plafond)/,
+			`variables interpolées dans la description de ${id}`
+		)
 	);
 });

--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -1806,21 +1806,6 @@ aides . brive:
   plafond: 200€
   lien: http://www.donzenac.correze.net/data/uploads/actualites/aide-velos-elec.pdf
 
-aides . communes riviera francaise:
-  remplace: commune
-  titre: Menton, Beausoleil, La Turbie, Fontan
-  applicable si:
-    toutes ces conditions:
-      - vélo . électrique
-      - une de ces conditions:
-          - localisation . code insee = '06083'
-          - localisation . code insee = '06012'
-          - localisation . code insee = '06150'
-          - localisation . code insee = '06062'
-  valeur: 150€
-  plafond: vélo . prix
-  lien: https://www.riviera-francaise.fr/les-actualites/item/236-prime-pour-l-achat-d-un-velo-electrique-il-est-encore-temps-d-en-profiter
-
 aides . hem:
   remplace: commune
   titre: Ville de Hem

--- a/src/lib/components/DetailsLine.svelte
+++ b/src/lib/components/DetailsLine.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { engine, getCurrentBikeEngine } from '$lib/engine';
-	import { formatValue } from 'publicodes';
+	import { formatDescription } from '$lib/utils';
 
 	import AnimatedAmount from './AnimatedAmount.svelte';
 	import Badge from './Badge.svelte';
@@ -10,16 +10,8 @@
 
 	$: aide = $getCurrentBikeEngine().evaluate(ruleName);
 
-	const defaultDescription = '';
-
 	const { title, rawNode } = engine.getRule(ruleName);
-	const description = rawNode.description ?? defaultDescription;
-	const plafondRuleName = `${ruleName} . $plafond`;
-	const plafondIsDefined = Object.keys(engine.parsedRules).includes(plafondRuleName);
-	const plafond = plafondIsDefined && engine.evaluate(plafondRuleName);
-	const notice = description
-		.replace(/\$vélo/g, veloCat === 'motorisation' ? 'kit de motorisation' : `vélo ${veloCat}`)
-		.replace(/\$plafond/, formatValue(plafond?.nodeValue, { displayedUnit: '€' }));
+	const notice = formatDescription({ ruleName, engine, veloCat });
 
 	const evaluateWithGivenRevenu = (revenu) =>
 		engine

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,3 +1,5 @@
+import { formatValue } from 'publicodes';
+
 export const removeAccents = (str) => str?.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 
 // First Google Search result, maybe there are better functions
@@ -16,4 +18,17 @@ export function slugify(str) {
 		.replace(/-+/g, '-');
 
 	return str;
+}
+
+// TODO: To we really need this feature? Could we automatically infer descriptions from the formulas?
+const defaultDescription = '';
+export function formatDescription({ ruleName, engine, veloCat }) {
+	const { rawNode } = engine.getRule(ruleName);
+	const description = rawNode?.description ?? defaultDescription;
+	const plafondRuleName = `${ruleName} . $plafond`;
+	const plafondIsDefined = Object.keys(engine.parsedRules).includes(plafondRuleName);
+	const plafond = plafondIsDefined && engine.evaluate(plafondRuleName);
+	return description
+		.replace(/\$vélo/g, veloCat === 'motorisation' ? 'kit de motorisation' : `vélo ${veloCat}`)
+		.replace(/\$plafond/, formatValue(plafond?.nodeValue, { displayedUnit: '€' }));
 }


### PR DESCRIPTION
- Permet d'obtenir la liste complète des aides
- Expose le numéro SIREN des EPCI
- Interpolation des variables dans les descriptions, fix #106
- Accepte le revenu fiscal de référence pour affiner le calcul
- Vérifie que chaque aide possède un titre et une description, fix #100