### PR TITLE
Corrige les tests unitaires suite à la fin des aides vélos de la ville de Strasbourg

### DIFF
--- a/tests/navigation.spec.js
+++ b/tests/navigation.spec.js
@@ -6,9 +6,9 @@ test('Navigation scenario', async ({ page }) => {
 	await page.goto(baseUrl);
 
 	await page.click('[placeholder*="Commune"]');
-	await page.fill('[placeholder*="Commune"]', 'stra');
+	await page.fill('[placeholder*="Commune"]', 'toulou');
 	await page.click('.autocomplete-list-item:first-child');
-	await expect(page).toHaveURL(baseUrl + '/ville/strasbourg');
+	await expect(page).toHaveURL(baseUrl + '/ville/toulouse');
 
 	// Hide evaporate animation
 	await page.addStyleTag({
@@ -17,12 +17,12 @@ test('Navigation scenario', async ({ page }) => {
 
 	await page.click('text=Achat d’un vélo électrique');
 	const totalAides = page.locator('text=Total des aides >> ..');
-	await expect(totalAides).toHaveText('Total des aides 900 €', { useInnerText: true });
+	await expect(totalAides).toHaveText('Total des aides 700 €', { useInnerText: true });
 
-	await page.click('label:last-child');
+	await page.click('label:nth-child(2)');
 	await expect(totalAides).toHaveText('Total des aides 500 €', { useInnerText: true });
 
-	await page.fill('input:below(label:text("Prix du vélo"))', '100');
+	await page.fill('input:below(label:text("Prix du vélo"))', '300');
 	await expect(totalAides).toHaveText('Total des aides 250 €', { useInnerText: true });
 
 	await page.goBack();


### PR DESCRIPTION
## Détails

Cette PR vise à corriger les tests unitaires qui ne passent plus suite au commit 2caf7634a6e06d52887d02b529a27e12131ee919 

L'échec des tests étant dû à la suppression des aides vélos pour la ville de Strasbourg ([réf](https://pokaa.fr/2022/06/02/mauvaise-surprise-laide-aux-velos-de-la-ville-de-strasbourg-nest-plus-disponible/)), ce correctif remplace la ville de Strasbourg dans les tests par la ville de Toulouse.