### PR TITLE
Répare le lien cassé

### DIFF
--- a/retrofit/routes/Footer.svelte
+++ b/retrofit/routes/Footer.svelte
@@ -24,7 +24,7 @@
 			</li>
 			<li>
 				<a
-					href="https://github.com/mquandalle/mesaidesvelo/retrofit"
+					href="https://github.com/mquandalle/mesaidesvelo/tree/master/retrofit"
 					target="_blank"
 					class="inline-flex gap-x-2 hover:(underline text-sky-600)"
 				>


### PR DESCRIPTION
Le lien vers le code source dans le pied de page est cassé. Cette PR le répare.