### PR TITLE
Ajoute la valeur de l'aide de la cc Loue Lison

### DIFF
--- a/src/aides.yaml
+++ b/src/aides.yaml
@@ -1465,6 +1465,7 @@ aides . loue lison:
     toutes ces conditions:
       - localisation . epci = 'CC Loue-Lison'
       - vélo . électrique
+  valeur: 200€
   lien: https://cclouelison.fr/fr/rb/1729730/mobilite-21
 
 aides . département somme:


### PR DESCRIPTION
J'ai remarqué qu'il manquait une valeur pour cette aide, d'après son lien, il s'agit d'un montant de 200€ (: