### PR TITLE
Incrémente le numéro de version du package-aides-velo

### DIFF
--- a/package-aides-velo/package.json
+++ b/package-aides-velo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "aides-velo",
-	"version": "3.0.7",
+	"version": "3.0.8",
 	"description": "Les aides vélos proposées en France",
 	"author": "Maxime Quandalle <maxime@mesaidesvelo.fr>",
 	"license": "AGPL-3.0-or-later",


### PR DESCRIPTION
Le publish des derniers commits sur master n'est pas fonctionnel car le numéro de version n'a pas été incrémenté.

Cela corrigera l'aide de Loue Lison qui a sa valeur collectivity.kind à `code insee` alors que c'est un `epci` 👍 