### PR TITLE
fix: le type Aide utilisé dans le package aides-velo est incomplet

### DIFF
--- a/package-aides-velo/index.ts
+++ b/package-aides-velo/index.ts
@@ -4,9 +4,15 @@ import aidesAndCollectivities from '$lib/data/aides-collectivities.json';
 import { formatDescription } from '$lib/utils';
 
 type Aide = {
+	id: string;
 	title: string;
 	description: string;
 	url: string;
+	collectivity: {
+		kind: string;
+		value: string;
+		code?: string;
+	}
 	/**
 	 * Le montant de l'aide est calculé seulement si le type de vélo a été
 	 * précisé en entrée.


### PR DESCRIPTION
## Détails

Le type Typescript `Aide` présent dans le fichier `packages-aides-velo/index.ts` est incomplet. Cette PR rajoute les clefs `id`, et `collectivity`.

En effet, une aide généré par la fonction `aidesVelo` présente dans ce même fichier aura la structure suivante : 
```javascript
{
  id: 'aides . bonus vélo',
  title: 'Bonus vélo',
  description: 'Nouveau bonus $vélo applicable du 15 août 2022 au 31 décembre 2023.\n',
  url: 'https://www.service-public.fr/particuliers/vosdroits/F36601',
  collectivity: {
    kind: 'pays',
    value: 'France'
  }
}
```

Les champs `collectivity.kind` et `collectivity.value` sont toujours présent dans la donnée provenant du fichier `aides-collectivities.json` mais pas forcément le champ `collectivity.code`.